### PR TITLE
Load Configuration File

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The main repository for the Emissions API
 * [psycopg2](https://pypi.org/project/psycopg2/)
 * [flask](https://flask.palletsprojects.com)
 * [geojson](https://pypi.org/project/geojson/)
+* PyYAML
 
 ## Installation
 

--- a/emissionsapi/config.py
+++ b/emissionsapi/config.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+'''
+Load and handle Emission API configuration.
+'''
+
+import yaml
+import os
+
+__config = {}
+
+
+def configuration_file():
+    '''Find the best match for the configuration file.  The configuration file
+    locations taken into consideration are (in this particular order):
+
+    - ./emissionsapi.yml
+    - ~/emissionsapi.yml
+    - /etc/emissionsapi.yml
+
+    :return: configuration file name or None
+    '''
+    if os.path.isfile('./emissionsapi.yml'):
+        return './emissionsapi.yml'
+    if os.path.isfile('~/emissionsapi.yml'):
+        return '~/emissionsapi.yml'
+    if os.path.isfile('/etc/emissionsapi.yml' ):
+        return '/etc/emissionsapi.yml'
+
+
+def update_configuration():
+    '''Update configuration.
+    '''
+    cfgfile = configuration_file()
+    if not cfgfile:
+        return {}
+    with open(cfgfile, 'r') as f:
+        cfg = yaml.safe_load(f)
+    globals()['__config'] = cfg
+    return cfg
+
+
+def config(key=None):
+    '''Get a specific configuration value or the whole configuration, loading
+    the configuration file if it was not before.
+
+    :param key: optional configuration key to return
+    :type key: string
+    :return: dictionary containing the configuration or configuration value
+    '''
+    cfg = __config or update_configuration()
+    return cfg.get(key) if key else cfg


### PR DESCRIPTION
This patch adds configuration file handling. Using this, we can easily
load configuration values like this:

```python
from emissionsapi.config import config
path = config('data-path') or 'data'
```

The configuration file locations taken into consideration are (in this
particular order):

- `./emissionsapi.yml`
- `~/emissionsapi.yml`
- `/etc/emissionsapi.yml`

Still open is the question how this relates to configuration stored in
environment variables as they are used right now in the database
modules:

```python
database = os.environ.get(
     'EMISSIONS_API',
     'postgresql://user:user@localhost/db')
```

Does it make sense to use the environment variables if no configuration
file exists? Or should an environment variable overwrite the
configuration file?

This fixes #11