### PR TITLE
Use unix timestamp from the nc file

### DIFF
--- a/emissionsapi/preprocess.py
+++ b/emissionsapi/preprocess.py
@@ -3,10 +3,9 @@
 import os
 
 import gdal
-import iso8601
 import numpy
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import emissionsapi.db
 import emissionsapi.logger
@@ -81,9 +80,9 @@ def read_file(ncfile):
 
     # Get time reference from the meta data.
     # Seems like there are named differently in the different gdal versions.
-    time_reference = iso8601.parse_date(
-        meta_data.get('NC_GLOBAL#time_reference') or
-        meta_data['time_reference'])
+    time_reference = datetime.fromtimestamp(int(
+        meta_data.get('NC_GLOBAL#time_reference_seconds_since_1970') or
+        meta_data['time_reference_seconds_since_1970']))
     timestamps = []
     for dt in deltatime:
         timestamps.append(time_reference + timedelta(milliseconds=dt.item()))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 flask
 gdal
 geoalchemy2
-iso8601
 numpy
 psycopg2
 sqlalchemy


### PR DESCRIPTION
So we can get rid of the iso8601 dependency

Signed-off-by: Sven Haardiek <sven@haardiek.de>