### PR TITLE
Introduce configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ Note that you do not need to install this project to run the different parts of 
 python setup.py install
 ```
 
+## Configuration
+
+Emissions API will look for configuration files in the following order:
+
+- ./emissionsapi.yml
+- ~/emissionsapi.yml
+- /etc/emissionsapi.yml
+
+A configuration file template can be found at `etc/emissionsapi.yml`. To get
+started, just copy this to the main project directory and adjust the values if
+the defaults do not work for you.
+
 ## Execute
 
 To execute the programs in this project run

--- a/emissionsapi/db.py
+++ b/emissionsapi/db.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import sessionmaker
 
 import geoalchemy2
 
+from emissionsapi.config import config
 import emissionsapi.logger
 
 # Logger
@@ -18,9 +19,7 @@ logger = emissionsapi.logger.getLogger('emission-api.db')
 # Database uri as described in
 # https://docs.sqlalchemy.org/en/13/core/engines.html#database-urls
 # Retrieved as environment variable.
-database = os.environ.get(
-    'EMISSIONS_API',
-    'postgresql://user:user@localhost/db')
+database = config('database') or 'postgresql://user:user@localhost/db'
 
 # Global session variable. Set on initialization.
 __session__ = None

--- a/emissionsapi/download.py
+++ b/emissionsapi/download.py
@@ -4,14 +4,16 @@
 import os
 import urllib3
 
+from emissionsapi.config import config
 import emissionsapi.logger
 
 # Logger
 logger = emissionsapi.logger.getLogger('emission-api.download')
 
+storage = config('storage') or 'data'
 
 def download():
-    os.makedirs('data', exist_ok=True)
+    os.makedirs(storage, exist_ok=True)
 
     # TODO: Replace this with sentinalsat
     filename = 'S5P_NRTI_L2__CO_____20190921T122303_20190921T122803_'\

--- a/emissionsapi/preprocess.py
+++ b/emissionsapi/preprocess.py
@@ -8,6 +8,7 @@ import numpy
 
 from datetime import timedelta
 
+from emissionsapi.config import config
 import emissionsapi.db
 import emissionsapi.logger
 
@@ -15,7 +16,7 @@ import emissionsapi.logger
 logger = emissionsapi.logger.getLogger('emission-api.preprocess')
 
 # Path where to store the data
-PATH = 'data'
+storage = config('storage') or 'data'
 
 # Specify the layer name to read
 LAYER_NAME = '//PRODUCT/carbonmonoxide_total_column'
@@ -38,10 +39,10 @@ class Scan():
 def list_ncfiles():
     """Generator yielding all nc files in download path.
     """
-    # Iterate through the files and directories in PATH
-    for f in os.listdir(PATH):
+    # Iterate through the files and directories in storage path
+    for f in os.listdir(storage):
         # Join directoriy and filename
-        filepath = os.path.join(PATH, f)
+        filepath = os.path.join(storage, f)
         # yield file ending with '.nc'
         if os.path.isfile(filepath) and filepath.endswith('.nc'):
             yield filepath

--- a/etc/emissionsapi.yml
+++ b/etc/emissionsapi.yml
@@ -1,0 +1,7 @@
+# PostgreSQL database configuration.
+# Default: postgresql://user:user@localhost/db
+database: postgresql://emissionsapi:emissionsapi@127.0.0.1/emissionsapi
+
+# Storage directory location.
+# Default: data
+storage: data


### PR DESCRIPTION
This patch introduces a configuration file for Emissions API.
It will look for configuration files in the following order:

- ./emissionsapi.yml
- ~/emissionsapi.yml
- /etc/emissionsapi.yml

A configuration file template can be found at `etc/emissionsapi.yml`. To get
started, just copy this to the main project directory and adjust the values if
the defaults do not work for you.

This fixes #14
This is related to #11