### PR TITLE
Revert "Use unix timestamp from the nc file"

### DIFF
--- a/emissionsapi/preprocess.py
+++ b/emissionsapi/preprocess.py
@@ -3,9 +3,10 @@
 import os
 
 import gdal
+import iso8601
 import numpy
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from emissionsapi.config import config
 import emissionsapi.db
@@ -81,9 +82,9 @@ def read_file(ncfile):
 
     # Get time reference from the meta data.
     # Seems like there are named differently in the different gdal versions.
-    time_reference = datetime.fromtimestamp(int(
-        meta_data.get('NC_GLOBAL#time_reference_seconds_since_1970') or
-        meta_data['time_reference_seconds_since_1970']))
+    time_reference = iso8601.parse_date(
+        meta_data.get('NC_GLOBAL#time_reference') or
+        meta_data['time_reference'])
     timestamps = []
     for dt in deltatime:
         timestamps.append(time_reference + timedelta(milliseconds=dt.item()))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 flask
 gdal
 geoalchemy2
+iso8601
 numpy
 psycopg2
 sqlalchemy


### PR DESCRIPTION
This reverts commit 8b705f09781609900f4cb35ce64ccd83dbd5a842.
times available "time_reference_seconds_since_1970" is empty in the nc file under windows