### PR TITLE
Switch to Connextion as Web Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ The main repository for the Emissions API
 * [SQLAlchemy](https://sqlalchemy.org)
 * [GeoAlchemy2](https://github.com/geoalchemy/geoalchemy2)
 * [psycopg2](https://pypi.org/project/psycopg2/)
-* [flask](https://flask.palletsprojects.com)
+* [Connexion](https://github.com/zalando/connexion)
+* [swagger-ui-bundle](https://pypi.org/project/swagger-ui-bundle/)
 * [geojson](https://pypi.org/project/geojson/)
 * PyYAML
 

--- a/emissionsapi/openapi.yml
+++ b/emissionsapi/openapi.yml
@@ -1,0 +1,62 @@
+openapi: 3.0.0
+info:
+  title: Emissions API
+  version: "0.1"
+paths:
+  /api/v1/geo.json/:
+    get:
+      operationId: emissionsapi.web.get_data
+      description: |
+          Get data in GeoJSON format.
+
+          You can only use one url parameter at a time.
+      parameters:
+        - $ref: '#/components/parameters/geoframe'
+        - $ref: '#/components/parameters/country'
+      responses:
+        200:
+          description: The Response contains all known points located within the specified rectangle contained in a GeoJSON feature collection.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/featurecollection'
+        400:
+          description: Parameter error
+
+components:
+  parameters:
+    geoframe:
+      in: query
+      name: geoframe
+      schema:
+        type: string
+      description: |
+          `geoframe` will let use define your own rectangle from which the data is chosen.
+          The Parameter must be in the form lo1,la1,lo2,la2 and represent the upper left and lower right corners of a rectangle.
+      example: 15,45,20,40
+    country:
+      in: query
+      name: country
+      schema:
+        type: string
+      description: "`country` will use a preselected rectangle countaing the specified country. Like 'DE'."
+      example: DE
+  schemas:
+    featurecollection:
+      description: GeoJSON Feature Collection
+      type: object
+      example:
+        features:
+          - geometry:
+              coordinates: [15.096772, 44.516739]
+              type: Point
+            properties:
+              carbonmonixide: 0.0273975990712643
+              type: Feature
+          - geometry:
+              coordinates: [15.063565, 44.561062]
+              type: Point
+            properties:
+              carbonmonixide: 0.0273975990712643
+              type: Feature
+        type: FeatureCollection

--- a/emissionsapi/web.py
+++ b/emissionsapi/web.py
@@ -1,9 +1,8 @@
 """Web Application to deliver the data stored in the database via an API to
 the users.
 """
-from flask import Flask, request, Response
+import connexion
 import geojson
-
 
 import emissionsapi.db
 import emissionsapi.logger
@@ -12,51 +11,23 @@ from emissionsapi.country_bounding_boxes import country_bounding_boxes
 # Logger
 logger = emissionsapi.logger.getLogger('emission-api.web')
 
-# Flask Web App
-app = Flask(__name__)
 
-
-@app.route('/api/v1/geo.json')
 @emissionsapi.db.with_session
-def get_data(session):
+def get_data(session, country=None, geoframe=None):
     """Get data in GeoJSON format.
-
-    URL parameters
-    ,,,,,,,,,,,,,,
-
-    You must use exactly one of these URL parameters.
-
-    * 'geoparam' expects 4 comma separated float values representing the
-      longitude and latitude of the upper left and lower right points of a
-      rectangle.
-    * `country` expects a two character country code which is mapped to a
-      minimal bounding box of that country as an alternative to specifying that
-      rectangle manually.
-
-    Response
-    ,,,,,,,,
-
-    The Response contains all known points located within the specified
-    rectangle contained in a GeoJSON feature collection.
-
-    Example
-    ,,,,,,,
-
-    You can try this with::
-
-        curl http://127.0.0.1:5000/api/v1/geo.json?geoparam=15,45,20,40
 
     :param session: SQLAlchemy session
     :type session: sqlalchemy.orm.session.Session
-    :return: GeoJSON response containing a feature collection
-    :rtype: flask.Response
+    :param country: 'country' url parameter
+    :type country: string
+    :param geoframe: 'geoframe' url parameter
+    :type geoframe: string
+    :return: Feature Collection with requested Points
+    :rtype: geojson.FeatureCollection
     """
-    # Get and parse URL parameter
-    geoparam = request.args.get('geoparam')
-    country = request.args.get('country')
-    if geoparam is not None:
+    if geoframe is not None:
         try:
-            lo1, lat1, lo2, lat2 = [float(x) for x in geoparam.split(',')]
+            lo1, lat1, lo2, lat2 = [float(x) for x in geoframe.split(',')]
         except ValueError:
             return 'Invalid geoparam', 400
     elif country is not None:
@@ -64,7 +35,7 @@ def get_data(session):
             return 'Unknown country code.', 400
         lo1, lat1, lo2, lat2 = country_bounding_boxes[country][1]
     else:
-        return 'You must specify either geoparam or country.', 400
+        return 'You must specify either geoframe or country.', 400
 
     # Init feature list
     features = []
@@ -77,17 +48,25 @@ def get_data(session):
             properties={"carbonmonixide": feature.value}))
     # Create feature collection from gathered points
     feature_collection = geojson.FeatureCollection(features)
-    return Response(
-        geojson.dumps(feature_collection, sort_keys=True),
-        mimetype='application/json')
+    return feature_collection
+
+
+# Create connexion app
+app = connexion.App(__name__)
+
+# Add swagger description to api
+app.add_api('openapi.yml', )
+
+# Create app to run with wsgi server
+application = app.app
 
 
 def entrypoint():
     """Entrypoint for running this as a module or from the binary.
-    It starts the Flask Debug Server. It is not meant to be used for
+    It starts the Connexion Debug Server. It is not meant to be used for
     production, but only during the development.
     """
-    logger.info("Starting the Flask Debug Server")
+    logger.info("Starting the Connexion Debug Server")
     app.run()
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-flask
 gdal
 geoalchemy2
 iso8601
@@ -6,3 +5,5 @@ numpy
 psycopg2
 sqlalchemy
 urllib3
+connexion
+swagger-ui-bundle


### PR DESCRIPTION
Since the most important feature of our API is to be easy usable, this commit
switch from flask to connexion as the web framework for the API.

With connexion the routing and documentation are automatically generated from a
openapi 3.0 configuration file and with swagger-ui-bundle an interactive
documenation is deployed under `/ui`.

This commit includes:

* A rudimentary OpenAPI documentation file
* Source code to switch from flask to connexion without loosing 

Signed-off-by: Sven Haardiek <sven@haardiek.de>