### PR TITLE
Download data from ESA

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The main repository for the Emissions API
 * [flask](https://flask.palletsprojects.com)
 * [geojson](https://pypi.org/project/geojson/)
 * PyYAML
+* [sentinalsat](https://github.com/sentinelsat/sentinelsat)
 
 These can be installed by executing
 

--- a/emissionsapi/download.py
+++ b/emissionsapi/download.py
@@ -1,10 +1,10 @@
 """Module to filter and download the data from the ESA and store it locally.
 """
 
-import os
-import urllib3
+from sentinelsat import SentinelAPI
 
 from emissionsapi.config import config
+from emissionsapi.country_bounding_boxes import country_bounding_boxes
 import emissionsapi.logger
 
 # Logger
@@ -12,19 +12,42 @@ logger = emissionsapi.logger.getLogger('emission-api.download')
 
 storage = config('storage') or 'data'
 
+# These credentials are provided publicly by ESA. There is no real user
+# management and we can keep it like this as long as they do not introduce
+# custom user accounts.
+user = 's5pguest'
+password = 's5pguest'
+url = 'https://s5phub.copernicus.eu/dhus'
+
+start_date = '20190910'
+end_date = '20190911'
+
+
+def bounding_box_to_wkt(lon1, lat1, lon2, lat2):
+    """Convert a bounding box specified by its top-left and bottom-right
+    coordinates to a wkt string defining a polygon.
+    """
+    return f'POLYGON(({lon1} {lat1},{lon1} {lat2},{lon2} {lat2},'\
+           f'{lon2} {lat1},{lon1} {lat1}))'
+
 
 def download():
-    os.makedirs(storage, exist_ok=True)
+    """Download data files from ESA and store them in the configured storage
+    directory.
+    """
+    wkt = bounding_box_to_wkt(*country_bounding_boxes['DE'][1])
 
-    # TODO: Replace this with sentinalsat
-    filename = 'S5P_NRTI_L2__CO_____20190921T122303_20190921T122803_'\
-        + '10046_01_010302_20190921T130405.nc'
-    url = 'https://data.lkiesow.io/emissions-api/' + filename
-    connection_pool = urllib3.PoolManager()
-    resp = connection_pool.request('GET', url)
-    with open('data/' + filename, 'wb') as f:
-        f.write(resp.data)
-    resp.release_conn()
+    # query api for available products
+    api = SentinelAPI(user, password, url)
+    products = api.query(area=wkt, date=(start_date, end_date))
+    products_df = api.to_dataframe(products)
+
+    # filter only one product of CO
+    where = products_df.producttypedescription == 'Carbon Monoxide'
+    one_id = products_df.uuid[where][0]
+
+    # download one product
+    api.download(one_id, directory_path=storage)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
+Pandas
 flask
 gdal
 geoalchemy2
 iso8601
 numpy
 psycopg2
+sentinelsat
 sqlalchemy
-urllib3


### PR DESCRIPTION
This patch includes the sentinelsat library to automatically request and
download data from ESA instead of just downloading a single file from a
custom server.

There are still a few things missing which should be improved and could
easily be added to the configuration file:

- Download multiple datasets, not just one
- Configure a time interval for which data is being downloaded
- Configure a country for which data is being downloaded

This fixes #1