### PR TITLE
Do not preprocess the same file twice

### DIFF
--- a/emissionsapi/db.py
+++ b/emissionsapi/db.py
@@ -3,7 +3,7 @@
 
 from functools import wraps
 
-from sqlalchemy import create_engine, Column, DateTime, Integer, Float
+from sqlalchemy import create_engine, Column, DateTime, Integer, Float, String
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
@@ -25,6 +25,14 @@ __session__ = None
 
 # Base Class of all ORM objects.
 Base = declarative_base()
+
+
+class File(Base):
+    """ORM Object for the nc files.
+    """
+    # Tablename
+    __tablename__ = 'file'
+    filename = Column(String, primary_key=True)
 
 
 class Carbonmonoxide(Base):


### PR DESCRIPTION
This commit add a new table to the database to store the files which have been
already imported.

Also it skips files which have been already processed while listing nc files so
that they are not processed twice.

Closes #20, Closes #37

Signed-off-by: Sven Haardiek <sven@haardiek.de>