### PR TITLE
Use sentinel5dl for download

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ The main repository for the Emissions API
 * [swagger-ui-bundle](https://pypi.org/project/swagger-ui-bundle/)
 * [geojson](https://pypi.org/project/geojson/)
 * PyYAML
-* [sentinelsat](https://github.com/sentinelsat/sentinelsat)
-* [Pandas](https://pandas.pydata.org/)
+* [sebtinel5dl](https://github.com/emissions-api/sentinel5dl)
 * [iso8601](https://pypi.org/project/iso8601/)
 
 These can be installed by executing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
-Pandas
+sentinel5dl
 gdal
 geoalchemy2
 iso8601
 numpy
 psycopg2
-sentinelsat
 sqlalchemy
 connexion
 swagger-ui-bundle


### PR DESCRIPTION
sentinalsat is licenced under the GPL 3 which is not compatible with our MIT
licence. Therefore we have to switch to our own tool sentinel5dl for
downloading files.

This closes #47 
This fixes #40 
This fixes #43 