### PR TITLE
Fix License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Lars Kiesow
+Copyright (c) 2019 The Emissions API Developers (https://emissions-api.org)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
II copied the file over from one of my other projects and have left my
name in the copyright clause. This patch fixes that by replacing it with
all Emissions API developers.