### PR TITLE
Listen to 127.0.0.1 only

### DIFF
--- a/emissionsapi/web.py
+++ b/emissionsapi/web.py
@@ -6,7 +6,6 @@ import geojson
 
 import emissionsapi.db
 import emissionsapi.logger
-from emissionsapi.config import config
 from emissionsapi.country_bounding_boxes import country_bounding_boxes
 
 # Logger
@@ -68,7 +67,7 @@ def entrypoint():
     production, but only during the development.
     """
     logger.info("Starting the Connexion Debug Server")
-    app.run(host=config('host') or '127.0.0.1')
+    app.run(host='127.0.0.1')
 
 
 if __name__ == "__main__":

--- a/emissionsapi/web.py
+++ b/emissionsapi/web.py
@@ -6,6 +6,7 @@ import geojson
 
 import emissionsapi.db
 import emissionsapi.logger
+from emissionsapi.config import config
 from emissionsapi.country_bounding_boxes import country_bounding_boxes
 
 # Logger
@@ -67,7 +68,7 @@ def entrypoint():
     production, but only during the development.
     """
     logger.info("Starting the Connexion Debug Server")
-    app.run()
+    app.run(host=config('host') or '127.0.0.1')
 
 
 if __name__ == "__main__":

--- a/etc/emissionsapi.yml
+++ b/etc/emissionsapi.yml
@@ -5,3 +5,8 @@ database: postgresql://emissionsapi:emissionsapi@127.0.0.1/emissionsapi
 # Storage directory location.
 # Default: data
 storage: data
+
+# Listening address for the built-in web server.
+# Note that this server is meant for development only.
+# Default: 127.0.0.1
+#host: 127.0.0.1

--- a/etc/emissionsapi.yml
+++ b/etc/emissionsapi.yml
@@ -5,8 +5,3 @@ database: postgresql://emissionsapi:emissionsapi@127.0.0.1/emissionsapi
 # Storage directory location.
 # Default: data
 storage: data
-
-# Listening address for the built-in web server.
-# Note that this server is meant for development only.
-# Default: 127.0.0.1
-#host: 127.0.0.1


### PR DESCRIPTION
This patch makes the Emissions API by default listen to localhost only
which is a safer and saner default. The default can be overwritten using
Emissions API's configuration file.