### PR TITLE
Fix Dependency Specification

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-sentinel5dl
+connexion
 gdal
 geoalchemy2
+geojson
 iso8601
 numpy
 psycopg2
+sentinel5dl
 sqlalchemy
-connexion
 swagger-ui-bundle
-iso8601


### PR DESCRIPTION
This patch fixes the list of libraries listed in the requirements.txt
where `geojson` was missing while `iso8601` was listed twice.