### PR TITLE
Github Pages URL Fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,9 @@ jobs:
         - touch docs/build/html/.nojekyll # create this file to prevent Github's Jekyll processing
       deploy:
         provider: pages
+        fqdn: docs.emissions-api.org
+        verbose: true
+        keep_history: true
         skip_cleanup: true
         github_token: $GITHUB_TOKEN
         local_dir: docs/build/html


### PR DESCRIPTION
Seems like the pages provider override our custom domain for the GitHub Pages.
By setting the `fqdn` for the pages provider.

Signed-off-by: Sven Haardiek <sven@haardiek.de>