### PR TITLE
Unify time parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is the main repository for the [Emissions API](https://emissions-api.org/).
 * [geojson](https://pypi.org/project/geojson/)
 * PyYAML
 * [sebtinel5dl](https://github.com/emissions-api/sentinel5dl)
-* [iso8601](https://pypi.org/project/iso8601/)
+* [python-dateutil](https://pypi.org/project/python-dateutil/)
 
 These can be installed by executing
 

--- a/emissionsapi/preprocess.py
+++ b/emissionsapi/preprocess.py
@@ -8,10 +8,9 @@ import logging
 import os
 
 import gdal
-import iso8601
+import dateutil.parser
+from dateutil.relativedelta import relativedelta
 import numpy
-
-from datetime import timedelta
 
 from emissionsapi.config import config
 import emissionsapi.db
@@ -97,12 +96,14 @@ def read_file(ncfile):
 
     # Get time reference from the meta data.
     # Seems like there are named differently in the different gdal versions.
-    time_reference = iso8601.parse_date(
+    time_reference = dateutil.parser.parse(
         meta_data.get('NC_GLOBAL#time_reference') or
         meta_data['time_reference'])
     timestamps = []
     for dt in deltatime:
-        timestamps.append(time_reference + timedelta(milliseconds=dt.item()))
+        timestamps.append(
+            time_reference + relativedelta(microseconds=dt.item())
+        )
     scan.timestamps = numpy.array(timestamps)
 
     return scan

--- a/emissionsapi/preprocess.py
+++ b/emissionsapi/preprocess.py
@@ -102,7 +102,7 @@ def read_file(ncfile):
     timestamps = []
     for dt in deltatime:
         timestamps.append(
-            time_reference + relativedelta(microseconds=dt.item())
+            time_reference + relativedelta(microseconds=1e3*dt.item())
         )
     scan.timestamps = numpy.array(timestamps)
 

--- a/emissionsapi/web.py
+++ b/emissionsapi/web.py
@@ -6,7 +6,7 @@
 the users.
 """
 import logging
-import datetime
+import dateutil.parser
 
 import connexion
 import geojson
@@ -49,14 +49,14 @@ def get_data(session, country=None, geoframe=None, begin=None, end=None):
     # Parse parameter begin
     try:
         if begin is not None:
-            begin = datetime.datetime.fromisoformat(begin)
+            begin = dateutil.parser.parse(begin)
     except ValueError:
         return 'Invalid begin', 400
 
     # Parse parameter end
     try:
         if end is not None:
-            end = datetime.datetime.fromisoformat(end)
+            end = dateutil.parser.parse(end)
     except ValueError:
         return 'Invalid end', 400
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 gdal>=2.2.0
 numpy>=1.10.0
 psycopg2>=2.6.0
-
 connexion==2.4.0
 GeoAlchemy2==0.6.3
 geojson==2.5.0
 iso8601==0.1.12
+python-dateutil==2.8.0
 sentinel5dl==0.4
 SQLAlchemy==1.3.10
 swagger-ui-bundle==0.0.5


### PR DESCRIPTION
This fixes #68

- Removed `datetime` and `iso8601` package from various Python modules.
- Replaced the two packages with `dateutil` and its analogous functions.

Things to note:
- `gdal` package is hard to install on Mac. It requires a certain version of the Mac OS. Testing was difficult.
- I removed `datetime.datetime.fromisoformat` even though that function would solve all the isoformat inconsistencies. I wasn't sure if `emissions-api` used Python 3.6 or Python 3.7.