### PR TITLE
Simplify Carbonmonoxide Database Object

### DIFF
--- a/emissionsapi/db.py
+++ b/emissionsapi/db.py
@@ -47,10 +47,6 @@ class Carbonmonoxide(Base):
     """ Data sample identifier (primary key)"""
     value = Column(Float)
     """Carbon monoxide value"""
-    longitude = Column(Float)
-    """Longitude of measurement"""
-    latitude = Column(Float)
-    """Latitude of measurement"""
     timestamp = Column(DateTime)
     """Timestamp of measurement"""
     geom = Column(geoalchemy2.Geometry(geometry_type="POINT"))
@@ -58,8 +54,6 @@ class Carbonmonoxide(Base):
 
     def __init__(self, value, longitude, latitude, timestamp):
         self.value = value
-        self.longitude = longitude
-        self.latitude = latitude
         self.timestamp = timestamp
         self.geom = geoalchemy2.elements.WKTElement(
             f"POINT({longitude} {latitude})")
@@ -122,10 +116,14 @@ def get_points(session, polygon=None, begin=None, end=None):
     :type begin: datetime.datetime, optional
     :param end: datetime.datetime, defaults to None
     :type end: Get only points before this timestamp, optional
-    :return: SQLAlchemy Query Object with the points from within the polygon.
+    :return: SQLAlchemy Query with tuple of Carbonmonoxide object,
+             longitude and latitude.
     :rtype: sqlalchemy.orm.query.Query
     """
-    query = session.query(Carbonmonoxide)
+    query = session.query(
+        Carbonmonoxide,
+        Carbonmonoxide.geom.ST_X(),
+        Carbonmonoxide.geom.ST_Y())
 
     # Filter with polygon
     if polygon is not None:

--- a/emissionsapi/web.py
+++ b/emissionsapi/web.py
@@ -65,13 +65,13 @@ def get_data(session, country=None, geoframe=None, begin=None, end=None):
     # Iterate through database query
     query = emissionsapi.db.get_points(
         session, polygon=rectangle, begin=begin, end=end)
-    for feature in query:
+    for obj, longitude, latitude in query:
         # Create and append single features.
         features.append(geojson.Feature(
-            geometry=geojson.Point((feature.longitude, feature.latitude)),
+            geometry=geojson.Point((longitude, latitude)),
             properties={
-                "carbonmonixide": feature.value,
-                "timestamp": feature.timestamp
+                "carbonmonoxide": obj.value,
+                "timestamp": obj.timestamp
             }))
     # Create feature collection from gathered points
     feature_collection = geojson.FeatureCollection(features)


### PR DESCRIPTION
We are currently storing longitude and latitude twice in the database.

With this patch the longitude and latitude is received from the Geometry object
from within the Carbonmonoxide object and changes the queries and API endpoints
respectively.

Signed-off-by: Sven Haardiek <sven@haardiek.de>