### PR TITLE
Bulk insert for Carbonmonixide Objects

### DIFF
--- a/emissionsapi/db.py
+++ b/emissionsapi/db.py
@@ -11,6 +11,7 @@ import logging
 from sqlalchemy import create_engine, Column, DateTime, Integer, Float, String
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.sql import text
 
 import geoalchemy2
 
@@ -102,6 +103,25 @@ def get_session():
 
     # Return new session object
     return __session__()
+
+
+def insert(session, data, table_name=Carbonmonoxide.__table__.name):
+    '''Batch insert data into the database using PostGIS specific functions.
+
+    :param session: SQL Alchemy Session
+    :type session: sqlalchemy.orm.session.Session
+    :param data: List of dictionaries with entries for timestamp, longitude,
+                 latitude and value
+    :type data: list
+    :param table_name: Name of database table to insert data into. Defaults to
+                       table for carbon monoxide values.
+    :type table_name: str
+    '''
+    statement = text(f'insert into {table_name} '
+                     '(value, timestamp, geom) '
+                     'values (:value, :timestamp, '
+                     '        ST_MakePoint(:longitude, :latitude))')
+    session.execute(statement, data)
 
 
 def get_points(session, polygon=None, begin=None, end=None):

--- a/emissionsapi/preprocess.py
+++ b/emissionsapi/preprocess.py
@@ -12,6 +12,7 @@ import iso8601
 import numpy
 
 from datetime import timedelta
+import geoalchemy2
 
 from emissionsapi.config import config
 import emissionsapi.db
@@ -151,6 +152,7 @@ def write_to_database(session, data):
     """
     # Iterate through the data of the Scan object
     shape = data.data.shape
+    inserts = []
     for i in range(shape[0]):
         for j in range(shape[1]):
 
@@ -160,15 +162,23 @@ def write_to_database(session, data):
                     numpy.isnan(data.latitude[i, j]) or
                     numpy.isnan(data.data[i, j]))):
 
-                # Add new carbon monoxide object to the session
-                session.add(
-                    emissionsapi.db.Carbonmonoxide(
-                        longitude=float(data.longitude[i, j]),
-                        latitude=float(data.latitude[i, j]),
-                        value=float(data.data[i, j]),
-                        timestamp=data.timestamps[i],
-                    )
-                )
+                # Create geometry wkt element
+                geom = geoalchemy2.elements.WKTElement(
+                    f"POINT({data.longitude[i, j]} {data.latitude[i, j]})")
+
+                # Append to list of elements to insert to database
+                inserts.append({
+                    'value': float(data.data[i, j]),
+                    'timestamp': data.timestamps[i],
+                    'geom': geom})
+
+    # Execute statement to insert multiple carbonmonoxide rows into the
+    # database
+    session.execute(
+        emissionsapi.db.Carbonmonoxide.metadata.tables['carbonmonoxide'].
+        insert(),
+        inserts,
+    )
 
     session.add(emissionsapi.db.File(filename=data.filename))
     # Commit the changes done in the session

--- a/emissionsapi/preprocess.py
+++ b/emissionsapi/preprocess.py
@@ -12,7 +12,6 @@ import iso8601
 import numpy
 
 from datetime import timedelta
-import geoalchemy2
 
 from emissionsapi.config import config
 import emissionsapi.db
@@ -152,7 +151,7 @@ def write_to_database(session, data):
     """
     # Iterate through the data of the Scan object
     shape = data.data.shape
-    inserts = []
+    scan_data = []
     for i in range(shape[0]):
         for j in range(shape[1]):
 
@@ -162,23 +161,15 @@ def write_to_database(session, data):
                     numpy.isnan(data.latitude[i, j]) or
                     numpy.isnan(data.data[i, j]))):
 
-                # Create geometry wkt element
-                geom = geoalchemy2.elements.WKTElement(
-                    f"POINT({data.longitude[i, j]} {data.latitude[i, j]})")
-
-                # Append to list of elements to insert to database
-                inserts.append({
+                # Add new carbon monoxide object to the session
+                scan_data.append({
                     'value': float(data.data[i, j]),
-                    'timestamp': data.timestamps[i],
-                    'geom': geom})
-
-    # Execute statement to insert multiple carbonmonoxide rows into the
-    # database
-    session.execute(
-        emissionsapi.db.Carbonmonoxide.metadata.tables['carbonmonoxide'].
-        insert(),
-        inserts,
-    )
+                    'longitude': float(data.longitude[i, j]),
+                    'latitude': float(data.latitude[i, j]),
+                    'timestamp': data.timestamps[i]
+                })
+    if scan_data:
+        emissionsapi.db.insert(session, scan_data)
 
     session.add(emissionsapi.db.File(filename=data.filename))
     # Commit the changes done in the session


### PR DESCRIPTION
Adding the Carbonmonoxide objects via the SQLAlchemy ORM is very slow. This
patch bypass the ORM and add the carbonmonoxide values directly to the
database.

Closes #15

Signed-off-by: Sven Haardiek <sven@haardiek.de>