### PR TITLE
Fix Typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is the main repository for the [Emissions API](https://emissions-api.org/).
 * [swagger-ui-bundle](https://pypi.org/project/swagger-ui-bundle/)
 * [geojson](https://pypi.org/project/geojson/)
 * PyYAML
-* [sebtinel5dl](https://github.com/emissions-api/sentinel5dl)
+* [sentinel5dl](https://github.com/emissions-api/sentinel5dl)
 * [iso8601](https://pypi.org/project/iso8601/)
 
 These can be installed by executing


### PR DESCRIPTION
There was a small typo in the `README.md`. Nothing flashy.