### PR TITLE
Use array to define geoframe in openapi

### DIFF
--- a/emissionsapi/openapi.yml
+++ b/emissionsapi/openapi.yml
@@ -40,11 +40,15 @@ components:
       in: query
       name: geoframe
       schema:
-        type: string
+        type: array
+        items:
+          type: number
+        maxItems: 4
+        minItems: 4
       description: |
           `geoframe` will let you define your own rectangle from which the data is chosen.
           The Parameter must be in the form lo1,la1,lo2,la2 and represent the upper left and lower right corners of a rectangle.
-      example: 15,45,20,40
+      example: [15, 45, 20, 40]
     country:
       in: query
       name: country

--- a/emissionsapi/web.py
+++ b/emissionsapi/web.py
@@ -36,8 +36,7 @@ def get_data(session, country=None, geoframe=None, begin=None, end=None):
     # Parse parameter geoframe
     if geoframe is not None:
         try:
-            rectangle = bounding_box_to_wkt(
-                *[float(x) for x in geoframe.split(',')])
+            rectangle = bounding_box_to_wkt(*geoframe)
         except ValueError:
             return 'Invalid geoparam', 400
     # parse parameter country


### PR DESCRIPTION
This patch uses an array of numbers for the geoframe instead of parsing it
manually from a string in the python code.

Signed-off-by: Sven Haardiek <sven@haardiek.de>