### PR TITLE
Add pagination to the API

### DIFF
--- a/emissionsapi/db.py
+++ b/emissionsapi/db.py
@@ -203,3 +203,26 @@ def filter_query(query, polygon=None, begin=None, end=None):
         query = query.filter(end > Carbonmonoxide.timestamp)
 
     return query
+
+
+def limit_offset_query(query, limit=None, offset=None):
+    """Apply limit and offset to the query.
+
+    :param query: SQL Alchemy Query
+    :type query: sqlalchemy.orm.Query
+    :param limit: Limit number of Items returned, defaults to None
+    :type limit: int, optional
+    :param offset: Specify the offset of the first hit to return,
+                   defaults to None
+    :type offset: int, optional
+    :return: SQLAlchemy Query with limit and offset applied.
+    :rtype: sqlalchemy.orm.query.Query
+    """
+    # Apply limit
+    if limit is not None:
+        query = query.limit(limit)
+
+    # Apply offset
+    if offset is not None:
+        query = query.offset(offset)
+    return query

--- a/emissionsapi/openapi.yml
+++ b/emissionsapi/openapi.yml
@@ -24,6 +24,8 @@ paths:
         - $ref: '#/components/parameters/country'
         - $ref: '#/components/parameters/begin'
         - $ref: '#/components/parameters/end'
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         200:
           description: The Response contains all known points located within the specified rectangle contained in a GeoJSON feature collection.
@@ -42,6 +44,8 @@ paths:
         - $ref: '#/components/parameters/country'
         - $ref: '#/components/parameters/begin'
         - $ref: '#/components/parameters/end'
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
       responses:
         200:
           description: Array of calculated averages.
@@ -54,6 +58,22 @@ paths:
 
 components:
   parameters:
+    limit:
+      in: query
+      name: limit
+      description: Limit number of Items returned.
+      schema:
+        type: integer
+        minimum: 0
+      example: 100
+    offset:
+      in: query
+      name: offset
+      description: Specify the offset of the first hit to return.
+      schema:
+        type: integer
+        minimum: 0
+      example: 100
     geoframe:
       in: query
       name: geoframe

--- a/emissionsapi/web.py
+++ b/emissionsapi/web.py
@@ -46,7 +46,8 @@ def parse_date(*keys):
 
 @parse_date('begin', 'end')
 @emissionsapi.db.with_session
-def get_data(session, country=None, geoframe=None, begin=None, end=None):
+def get_data(session, country=None, geoframe=None, begin=None, end=None,
+             limit=None, offset=None):
     """Get data in GeoJSON format.
 
     :param session: SQLAlchemy session
@@ -76,6 +77,10 @@ def get_data(session, country=None, geoframe=None, begin=None, end=None):
     # Iterate through database query
     query = emissionsapi.db.get_points(
         session, polygon=rectangle, begin=begin, end=end)
+    # Apply limit and offset
+    query = emissionsapi.db.limit_offset_query(
+        query, limit=limit, offset=offset)
+
     for obj, longitude, latitude in query:
         # Create and append single features.
         features.append(geojson.Feature(
@@ -91,7 +96,8 @@ def get_data(session, country=None, geoframe=None, begin=None, end=None):
 
 @parse_date('begin', 'end')
 @emissionsapi.db.with_session
-def get_average(session, country=None, geoframe=None, begin=None, end=None):
+def get_average(session, country=None, geoframe=None, begin=None, end=None,
+                limit=None, offset=None):
     rectangle = None
     # Parse parameter geoframe
     if geoframe is not None:
@@ -107,6 +113,9 @@ def get_average(session, country=None, geoframe=None, begin=None, end=None):
 
     query = emissionsapi.db.get_averages(
         session, polygon=rectangle, begin=begin, end=end)
+    # Apply limit and offset
+    query = emissionsapi.db.limit_offset_query(
+        query, limit=limit, offset=offset)
 
     result = []
     for avg, max_time, min_time, _ in query:


### PR DESCRIPTION
This patch introduces the query parameter `offset` and `limit` to introduce pagination on our API.

This does not apply to the [JSON:API Pagination](https://jsonapi.org/examples/#pagination), since both connexion and the swagger-ui-bundle does not handle query parameters in the form `page[limit]` well as explained in #89.

Nonetheless we should be able to extend this pagination later with links in the response, if we wish to do that.

Closes #89