### PR TITLE
Redirect / to Swagger UI

### DIFF
--- a/emissionsapi/web.py
+++ b/emissionsapi/web.py
@@ -10,6 +10,7 @@ import dateutil.parser
 
 import connexion
 import geojson
+from flask import redirect
 
 import emissionsapi.db
 from emissionsapi.country_bounding_boxes import country_bounding_boxes
@@ -125,6 +126,16 @@ app.add_api('openapi.yml', )
 
 # Create app to run with wsgi server
 application = app.app
+
+
+@app.route('/')
+def home():
+    """Redirect / to the swagger ui
+
+    :return: Redirect response
+    :rtype: werkzeug.wrappers.response.Response
+    """
+    return redirect('/ui', code=302)
 
 
 def entrypoint():


### PR DESCRIPTION
We do not need an explicit landing page, if we simply redirect the request
directly to the ui of the live documentation.

Closes #93