### PR TITLE
Expand User in Config File

### DIFF
--- a/emissionsapi/config.py
+++ b/emissionsapi/config.py
@@ -24,8 +24,9 @@ def configuration_file():
     '''
     if os.path.isfile('./emissionsapi.yml'):
         return './emissionsapi.yml'
-    if os.path.isfile('~/emissionsapi.yml'):
-        return '~/emissionsapi.yml'
+    expanded_file = os.path.expanduser('~/emissionsapi.yml')
+    if os.path.isfile(expanded_file):
+        return expanded_file
     if os.path.isfile('/etc/emissionsapi.yml'):
         return '/etc/emissionsapi.yml'
 


### PR DESCRIPTION
This patch fixes the usage of config files in the home directory by actually
expanding the '~' to the home directory.