### PR TITLE
Introduce Point Query Parameter

### DIFF
--- a/emissionsapi/openapi.yml
+++ b/emissionsapi/openapi.yml
@@ -20,15 +20,17 @@ paths:
       description: |
           Get all points in [GeoJSON](https://geojson.org/) format.
 
-          The parameters `geoframe`, `country` and `polygon` overwrite each other so that only one will be used even if multiple parameters are provided.
+          The parameters `geoframe`, `country`, `polygon` and `point` overwrite each other so that only one will be used even if multiple parameters are provided.
           The order of parameter precedence is:
             1. geoframe
             2. country
             3. polygon
+            4. point
       parameters:
         - $ref: '#/components/parameters/geoframe'
         - $ref: '#/components/parameters/country'
         - $ref: '#/components/parameters/polygon'
+        - $ref: '#/components/parameters/point'
         - $ref: '#/components/parameters/begin'
         - $ref: '#/components/parameters/end'
         - $ref: '#/components/parameters/limit'
@@ -48,15 +50,17 @@ paths:
       description: |
           Get daily average for a specified area filtered by time.
 
-          The parameters `geoframe`, `country` and `polygon` overwrite each other so that only one will be used even if multiple parameters are provided.
+          The parameters `geoframe`, `country`, `polygon` and `point` overwrite each other so that only one will be used even if multiple parameters are provided.
           The order of parameter precedence is:
             1. geoframe
             2. country
             3. polygon
+            4. point
       parameters:
         - $ref: '#/components/parameters/geoframe'
         - $ref: '#/components/parameters/country'
         - $ref: '#/components/parameters/polygon'
+        - $ref: '#/components/parameters/point'
         - $ref: '#/components/parameters/begin'
         - $ref: '#/components/parameters/end'
         - $ref: '#/components/parameters/limit'
@@ -76,16 +80,18 @@ paths:
       description: |
           Get statistical values for specified time intervals.
 
-          The parameters `geoframe`, `country` and `polygon` overwrite each other so that only one will be used even if multiple parameters are provided.
+          The parameters `geoframe`, `country`, `polygon` and `point` overwrite each other so that only one will be used even if multiple parameters are provided.
           The order of parameter precedence is:
             1. geoframe
             2. country
             3. polygon
+            4. point
       parameters:
-        - $ref: '#/components/parameters/interval'
         - $ref: '#/components/parameters/geoframe'
         - $ref: '#/components/parameters/country'
         - $ref: '#/components/parameters/polygon'
+        - $ref: '#/components/parameters/point'
+        - $ref: '#/components/parameters/interval'
         - $ref: '#/components/parameters/begin'
         - $ref: '#/components/parameters/end'
         - $ref: '#/components/parameters/limit'
@@ -143,6 +149,19 @@ components:
         The parameter must be in the form `lon1,lat1,lon2,lat2`,
         representing the upper left and lower right corners of a rectangle.
       example: [15, 45, 20, 40]
+    point:
+      in: query
+      name: point
+      schema:
+        type: array
+        items:
+          type: number
+        maxItems: 2
+        minItems: 2
+      description: |
+          Defines a single `point` in the form longitude,latitude.
+          Only data in approximately 22km radius around this point is considered for the result.
+      example: [8.0498, 52.27264]
     country:
       in: query
       name: country


### PR DESCRIPTION
This patch introduces points as query parameter. So it is possible to define a
point and the result is filtered for a small area around this point. This is
the implementation of the [NOZ user story](https://github.com/emissions-api/project-notes/blob/master/user-stories/user-story-noz.md)

To make it more readable it also splits the database `get_*` function and the filter functions.
So we do not have to propagade the parameter through all those functions.