### PR TITLE
Increase Speed of Daily Averages

### DIFF
--- a/emissionsapi/db.py
+++ b/emissionsapi/db.py
@@ -166,7 +166,7 @@ def get_averages(session, polygon=None, begin=None, end=None):
              truncated by day.
     :rtype: sqlalchemy.orm.query.Query
     """
-    day = sqlalchemy.func.date_trunc('day', Carbonmonoxide.timestamp)
+    day = sqlalchemy.func.date(Carbonmonoxide.timestamp)
     query = session.query(
         sqlalchemy.func.avg(Carbonmonoxide.value),
         sqlalchemy.func.max(Carbonmonoxide.timestamp),


### PR DESCRIPTION
This patch switches from using PostgreSQL's `date_trunc()` to using
`date()` for grouping since it is somewhat feaster albeit less flexible.
But we do not need the flexibility anyway.

Using `date_trunc()`:

```
% repeat 10 /usr/bin/time -p curl -s -X GET "http://127.0.0.1:5000/api/v1/average.json/" -o /dev/null
real 0.83
real 0.84
real 0.81
real 0.83
real 0.81
real 0.84
real 0.82
real 0.81
real 0.83
real 0.83
```

Using `date()`:

```
% repeat 10 /usr/bin/time -p curl -s -X GET "http://127.0.0.1:5000/api/v1/average.json/" -o /dev/null
real 0.68
real 0.69
real 0.68
real 0.67
real 0.69
real 0.68
real 0.67
real 0.67
real 0.68
real 0.68
```