### PR TITLE
Use Alembic for Database Migration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,3 +109,21 @@ There is a simple ``docker-compose.yml`` file to make it easier to setup a
 database for development.
 
 You can also setup the database on your own.
+
+Database Migration
+^^^^^^^^^^^^^^^^^^
+
+For database migration we are using `Alembic <https://alembic.sqlalchemy.org/en/latest/>`_.
+If you have a database that is already on the latest database schema, just execute
+
+.. code-block:: bash
+
+   alembic stamp head
+
+to add the alembic metadata to the database and make it ready for later migration.
+
+If you want to migrate your database to the latest version, just execute
+
+.. code-block:: bash
+
+   alembic upgrade head

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,84 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = alembic
+
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# timezone to use when rendering the date
+# within the migration file as well as the filename.
+# string value is passed to dateutil.tz.gettz()
+# leave blank for localtime
+timezone = utc
+
+# max length of characters to apply to the
+# "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; this defaults
+# to alembic/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path
+# version_locations = %(here)s/bar %(here)s/bat alembic/versions
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+# sqlalchemy.url = driver://user:pass@localhost/dbname
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks=black
+# black.type=console_scripts
+# black.entrypoint=black
+# black.options=-l 79
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,83 @@
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+
+from alembic import context
+
+import emissionsapi.db
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+
+# We are using our own config to specify the database url
+# instead of using it from the .ini file
+config.set_main_option('sqlalchemy.url', emissionsapi.db.database)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = emissionsapi.db.Base.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection, target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/f781a3528157_add_carbonmonixide_timestamp_index.py
+++ b/alembic/versions/f781a3528157_add_carbonmonixide_timestamp_index.py
@@ -1,0 +1,25 @@
+"""add carbonmonoxide.timestamp index
+
+Revision ID: f781a3528157
+Revises:
+Create Date: 2019-11-17 14:26:01.702418+00:00
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'f781a3528157'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(op.f('ix_carbonmonoxide_timestamp'),
+                    'carbonmonoxide', ['timestamp'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_carbonmonoxide_timestamp'),
+                  table_name='carbonmonoxide')

--- a/emissionsapi/db.py
+++ b/emissionsapi/db.py
@@ -40,6 +40,11 @@ psycopg2.extensions.register_adapter(
         lambda arr: psycopg2.extensions.adapt(list(arr)))
 
 
+class AlembicVersion(Base):
+    __tablename__ = 'alembic_version'
+    version_num = Column(String(32), primary_key=True)
+
+
 class File(Base):
     """ORM object for the nc files.
     """
@@ -99,7 +104,7 @@ class Carbonmonoxide(Base):
     """ Data sample identifier (primary key)"""
     value = Column(Float)
     """Carbon monoxide value"""
-    timestamp = Column(DateTime)
+    timestamp = Column(DateTime, index=True)
     """Timestamp of measurement"""
     geom = Column(geoalchemy2.Geometry(geometry_type="POINT"))
     """Location (PostGis type)"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 psycopg2>=2.6.0
+alembic==1.3.1
 connexion==2.4.0
 GeoAlchemy2==0.6.3
 geojson==2.5.0


### PR DESCRIPTION
This patch introduce Alembic as the database migration program.
None of the migration steps are executed automatically, but with alembic as a dependency a new binary `alembic` is installed and database migration can by done by executing

```bash
alembic upgrade <revision>
```

from the main directory.

Most of the scripts in `alembic` are auto generated and only slightly modified.

To not only add an empty configuration, this patch also introduce an index for the timestamp column of the carbonmonoxide table.

Here a comparison from a simple call to the database before and after adding the index:

```bash
$ repeat 10 /usr/bin/time -p curl -X GET "http://127.0.0.1:5000/api/v1/statistics.json?country=US&interval=day&begin=2019-02-01&end=2019-02-04&offset=0" -H  "accept: application/json" -o /dev/null 2>&1 | grep real
real 5.11
real 5.13
real 5.15
real 5.18
real 5.14
real 5.14
real 5.13
real 5.13
real 5.11
real 5.11

$ repeat 10 /usr/bin/time -p curl -X GET "http://127.0.0.1:5000/api/v1/statistics.json?country=US&interval=day&begin=2019-02-01&end=2019-02-04&offset=0" -H  "accept: application/json" -o /dev/null 2>&1 | grep real
real 2.27
real 1.87
real 1.86
real 1.87
real 1.87
real 1.87
real 1.87
real 1.86
real 1.86
real 1.86
```