### PR TITLE
Make log level configurable

### DIFF
--- a/emissionsapi/__init__.py
+++ b/emissionsapi/__init__.py
@@ -16,7 +16,10 @@ data analysis and without having to process terabytes of data.
 # See LICENSE fore more information.
 import logging
 
+from emissionsapi.config import config
+
 logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    level=logging.INFO,
+    level=config('loglevel') or logging.INFO,
 )
+logging.debug('Log level set to: %s', logging.getLogger().getEffectiveLevel())

--- a/etc/emissionsapi.yml
+++ b/etc/emissionsapi.yml
@@ -6,6 +6,10 @@ database: postgresql://emissionsapi:emissionsapi@127.0.0.1/emissionsapi
 # Default: data
 storage: data
 
+# Configure the log level of the root logger.
+# Default: INFO
+#loglevel: INFO
+
 # Configure which data to download from the ESA archives
 download:
   date:


### PR DESCRIPTION
This patch makes the log level configurable with the default log level
set to INFO.

This fixes #124