### PR TITLE
Request Caching

### DIFF
--- a/emissionsapi/preprocess.py
+++ b/emissionsapi/preprocess.py
@@ -7,6 +7,7 @@
 import datetime
 import logging
 import os
+from dateutil import tz
 
 import s5a
 
@@ -49,8 +50,8 @@ def write_to_database(session, data):
     """
     # Iterate through the points of the Scan object
     points = []
-    time_min = datetime.datetime.max
-    time_max = datetime.datetime.min
+    time_min = datetime.datetime.now().astimezone(tz.tzutc())
+    time_max = datetime.datetime.fromtimestamp(0).astimezone(tz.tzutc())
     for point in data.points:
         points.append({
             'value': point.value,

--- a/emissionsapi/web.py
+++ b/emissionsapi/web.py
@@ -10,8 +10,9 @@ import logging
 import dateutil.parser
 
 import connexion
+import json
 import geojson
-from flask import redirect
+from flask import redirect, request
 
 import emissionsapi.db
 from emissionsapi.country_bounding_boxes import country_bounding_boxes
@@ -98,6 +99,63 @@ def parse_wkt(f):
     return decorated
 
 
+def cache_with_session(begin_name=None, end_name=None):
+    """Function decorator caching responses based on their request parameters
+    in the PostgreSQL database.
+
+    The established database session is passed to the wrapped function as first
+    argument much like :func:`~emissionsapi.db.with_session` in case no cached
+    value for this request is present yet.
+
+    Argument names for the beginning and the end of a time frame can be passed
+    to this decorator. They will automatically be parsed as datetime and stored
+    alongside the cached data to determine if the cached values needs to be
+    purged when importing new data.
+
+    :param begin_name: Name of the argument containing the value defining the
+                       beginning of the requested time frame.
+    :type begin_name: string
+    :param end_name: Name of the argument containing the value defining the end
+                     of the requested time frame.
+    :type end_name: string
+    :return: decorator
+    :rtype: func
+    """
+    def decorator(function):
+        date_args = [x for x in [begin_name, end_name] if x]
+
+        @parse_date(*date_args)
+        @emissionsapi.db.with_session
+        @wraps(function)
+        def wrapper(session, *args, **kwargs):
+            # Internal parameter for debugging possible future cache problems
+            # Deliberately not publishing this via OpenAPI specification
+            if request.args.get('cache', '1').lower() in ['false', 'no', '0']:
+                return function(session, *args, **kwargs)
+            # get time frame parameters
+            begin = begin_name and kwargs.get(begin_name)
+            end = end_name and kwargs.get(end_name)
+
+            # construct a primary key for this request
+            req = json.dumps((request.path, request.args), sort_keys=True)
+            for cache in session.query(emissionsapi.db.Cache)\
+                                .filter(emissionsapi.db.Cache.request == req):
+                logger.debug('Using cache')
+                return cache.response
+
+            # not in cache, put in cache
+            result = function(session, *args, **kwargs)
+            session.add(emissionsapi.db.Cache(
+                request=req,
+                begin=begin,
+                end=end,
+                response=result))
+            session.commit()
+            return result
+        return wrapper
+    return decorator
+
+
 @parse_wkt
 @parse_date('begin', 'end')
 @emissionsapi.db.with_session
@@ -149,8 +207,7 @@ def get_data(session, wkt=None, distance=None, begin=None, end=None,
 
 
 @parse_wkt
-@parse_date('begin', 'end')
-@emissionsapi.db.with_session
+@cache_with_session('begin', 'end')
 def get_average(session, wkt=None, distance=None, begin=None, end=None,
                 limit=None, offset=None, **kwargs):
     """Get daily average for a specified area filtered by time.
@@ -192,8 +249,7 @@ def get_average(session, wkt=None, distance=None, begin=None, end=None,
 
 
 @parse_wkt
-@parse_date('begin', 'end')
-@emissionsapi.db.with_session
+@cache_with_session('begin', 'end')
 def get_statistics(session, interval='day', wkt=None, distance=None,
                    begin=None, end=None, limit=None, offset=None, **kwargs):
     """Get statistical data like amount, average, min, or max values for a


### PR DESCRIPTION
This patch implements a permanent request cache for the average and
statistics endpoints. Successful requests are stored in a dedicated
database table when they have been requested for the first time.

The next identical request is then served from this cache instead of
generating the result yet again.