### PR TITLE
Use Log Formatter

### DIFF
--- a/emissionsapi/download.py
+++ b/emissionsapi/download.py
@@ -49,7 +49,7 @@ def filtered_download(polygon=None, begin_ts=None, end_ts=None):
             end_ts=end_ts,
             product=product,
             processing_level=processing_level)
-    logger.info('Found {0} products'.format(len(result.get('products'))))
+    logger.info('Found %s products', len(result.get('products')))
 
     # Download data
     sentinel5dl.download(result.get('products'), output_dir=storage)
@@ -71,8 +71,8 @@ def download():
     os.makedirs(storage, exist_ok=True)
 
     if countries is None:
-        logger.info(
-            f'Looking for products between {date_begin} and {date_end}.')
+        logger.info('Looking for products between %s and %s.',
+                    date_begin, date_end)
         filtered_download(
             begin_ts=date_begin,
             end_ts=date_end,
@@ -81,9 +81,8 @@ def download():
 
     for country in countries:
         polygon = bounding_box_to_wkt(*country_bounding_boxes[country][1])
-        logger.info(
-            f'Looking for products in country {country} '
-            f'between {date_begin} and {date_end}.')
+        logger.info('Looking for products in country %s between %s and %s.',
+                    country, date_begin, date_end)
         filtered_download(
             polygon=polygon,
             begin_ts=date_begin,

--- a/emissionsapi/preprocess.py
+++ b/emissionsapi/preprocess.py
@@ -30,7 +30,7 @@ def list_ncfiles(session):
         # Check if file was already added
         if session.query(emissionsapi.db.File)\
                   .filter(emissionsapi.db.File.filename == f).count():
-            logger.info(f"Skipping {f}")
+            logger.info("Skipping %s", f)
             continue
         # Join directory and filename
         filepath = os.path.join(storage, f)
@@ -81,14 +81,14 @@ def entrypoint():
     """
     # Iterate through all find nc files
     for ncfile in list_ncfiles():
-        logger.info(f"Pre-process '{ncfile}'")
+        logger.info("Pre-processing '%s'", ncfile)
         # Read data from nc file
-        logger.info(f"Read file '{ncfile}'")
+        logger.info("Reading file '%s'", ncfile)
         scan = s5a.Scan(ncfile)
-        logger.info(f"Filter {scan.len()} points by quality")
+        logger.info("Filtering %s points by quality", scan.len())
         # filter data for quality >=50
         scan.filter_by_quality(50)
-        logger.info(f"Write {scan.len()} points to database")
+        logger.info("Writing %s points to the database", scan.len())
         # Write the filtered data to the database
         write_to_database(scan)
     pass

--- a/emissionsapi/web.py
+++ b/emissionsapi/web.py
@@ -36,7 +36,7 @@ def parse_date(*keys):
         @wraps(function)
         def wrapper(*args, **kwargs):
             for key in keys:
-                logger.debug(f'Try to parse {key} as date')
+                logger.debug('Try parsing %s as date', key)
                 date = kwargs.get(key)
                 if date is None:
                     continue
@@ -67,13 +67,13 @@ def parse_wkt(f):
         # Parse parameter geoframe
         if geoframe is not None:
             try:
-                logger.debug('Try to parse geoframe')
+                logger.debug('Try parsing geoframe')
                 kwargs['wkt'] = bounding_box_to_wkt(*geoframe)
             except ValueError:
                 return 'Invalid geoparam', 400
         # parse parameter country
         elif country is not None:
-            logger.debug('Try to parse country')
+            logger.debug('Try parsing country')
             if country not in country_bounding_boxes:
                 return 'Unknown country code.', 400
             kwargs['wkt'] = bounding_box_to_wkt(
@@ -81,7 +81,7 @@ def parse_wkt(f):
         # parse parameter polygon
         elif polygon is not None:
             try:
-                logger.debug('Try to parse polygon')
+                logger.debug('Try parsing polygon')
                 kwargs['wkt'] = polygon_to_wkt(polygon)
             except RESTParamError as err:
                 return str(err), 400


### PR DESCRIPTION
This patch homogenizes the log messages using the same pattern and tense
and switching to the logger's own string formatting mechanism to avoid
always preparing the log string regardless of them being needed or not.