### PR TITLE
Clean-up Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,33 +2,21 @@ language: python
 
 dist: bionic
 
-virtualenv:
-  system_site_packages: true
-
 python: "3.6"
 
-jobs:
-  include:
-    - stage: deployment
-      env: name=gh-pages
-      addons:
-        apt:
-          packages:
-            - python3-pycurl
-      install:
-        - pip install sphinx sphinx-rtd-theme
-        - pip install -r requirements.txt
-      script:
-        - make -C docs clean html
-        - touch docs/build/html/.nojekyll # create this file to prevent Github's Jekyll processing
-      deploy:
-        provider: pages
-        fqdn: docs.emissions-api.org
-        verbose: true
-        keep_history: true
-        skip_cleanup: true
-        github_token: $GITHUB_TOKEN
-        local_dir: docs/build/html
-      on:
-        branch: master
-        repo: emissions-api/emissions-api
+install:
+  - pip install sphinx sphinx-rtd-theme
+script:
+  - make -C docs clean html
+  - touch docs/build/html/.nojekyll # create this file to prevent Github's Jekyll processing
+deploy:
+  provider: pages
+  fqdn: docs.emissions-api.org
+  verbose: true
+  keep_history: true
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN
+  local_dir: docs/build/html
+  on:
+    branch: master
+    repo: emissions-api/emissions-api


### PR DESCRIPTION
This patch removes unnecessary Python libraries from the Travis builds
for the documentation.