### PR TITLE
Autopep8 compatible formatting

### DIFF
--- a/emissionsapi/web.py
+++ b/emissionsapi/web.py
@@ -280,7 +280,9 @@ def get_statistics(session, interval='day', wkt=None, distance=None,
     query = emissionsapi.db.limit_offset_query(
         query, limit=limit, offset=offset)
 
-    return [{'value': {
+    return [
+        {
+            'value': {
                 'count': count,
                 'average': avg,
                 'standard deviation': stddev,
@@ -289,9 +291,10 @@ def get_statistics(session, interval='day', wkt=None, distance=None,
             'time': {
                 'min': min_time,
                 'max': max_time,
-                'interval_start': inter}}
-            for count, avg, stddev, min_val, max_val, min_time, max_time, inter
-            in query]
+                'interval_start': inter}
+        }
+        for count, avg, stddev, min_val, max_val, min_time, max_time, inter
+        in query]
 
 
 # Create connexion app


### PR DESCRIPTION
This patch makes the `emissionsapi/web.py` file autopep8 formatted again while
trying to be as clear as before for some already pep8 compatible formattings.