### PR TITLE
Drop 'id' from carbonmonoxide table

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,9 @@ jobs:
           name: migrate database
           command: |
               ./env/bin/python setup.py install
+              CURRENT_VERSION=$(./env/bin/alembic current | cut -d ' ' -f 1)
               ./env/bin/alembic upgrade head
+              ./env/bin/alembic downgrade $CURRENT_VERSION
 
 workflows:
   version: 2

--- a/alembic/versions/22ea33634af6_drop_primary_key_of_carbonmonoxide.py
+++ b/alembic/versions/22ea33634af6_drop_primary_key_of_carbonmonoxide.py
@@ -1,0 +1,44 @@
+"""Drop primary key of carbonmonoxide
+
+Revision ID: 22ea33634af6
+Revises: f781a3528157
+Create Date: 2019-12-23 09:58:44.978470+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.schema import Sequence, CreateSequence
+
+
+# revision identifiers, used by Alembic.
+revision = '22ea33634af6'
+down_revision = 'f781a3528157'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Drop id as primary key
+    op.drop_column('carbonmonoxide', 'id')
+
+    # Drop index on timestamp
+    op.drop_index('ix_carbonmonoxide_timestamp')
+
+    # Use ('timestamp', 'geom') as the new primary key
+    op.create_primary_key('carbonmonoxide_pkey',
+                          'carbonmonoxide', ['timestamp', 'geom'])
+
+
+def downgrade():
+    # Create new column 'id' and autoincrement its value
+    op.execute(CreateSequence(Sequence("carbonmonoxide_id_seq")))
+    op.add_column('carbonmonoxide', sa.Column(
+        'id', sa.INTEGER(), nullable=False,
+        server_default=sa.text("nextval('carbonmonoxide_id_seq'::regclass)")))
+
+    # Drop primary key
+    op.drop_constraint('carbonmonoxide_pkey',
+                       'carbonmonoxide', type_='primary')
+
+    # Use 'id' as the new primary key
+    op.create_primary_key('carbonmonoxide_pkey', 'carbonmonoxide', ['id'])

--- a/alembic/versions/b3ae57ee07d4_drop_carbonmonoxide_id.py
+++ b/alembic/versions/b3ae57ee07d4_drop_carbonmonoxide_id.py
@@ -1,8 +1,8 @@
-"""Drop primary key of carbonmonoxide
+"""drop carbonmonoxide id
 
-Revision ID: 22ea33634af6
+Revision ID: b3ae57ee07d4
 Revises: f781a3528157
-Create Date: 2019-12-23 09:58:44.978470+00:00
+Create Date: 2019-12-31 17:30:56.008352+00:00
 
 """
 from alembic import op
@@ -11,7 +11,7 @@ from sqlalchemy.schema import Sequence, CreateSequence
 
 
 # revision identifiers, used by Alembic.
-revision = '22ea33634af6'
+revision = 'b3ae57ee07d4'
 down_revision = 'f781a3528157'
 branch_labels = None
 depends_on = None
@@ -21,13 +21,6 @@ def upgrade():
     # Drop id as primary key
     op.drop_column('carbonmonoxide', 'id')
 
-    # Drop index on timestamp
-    op.drop_index('ix_carbonmonoxide_timestamp')
-
-    # Use ('timestamp', 'geom') as the new primary key
-    op.create_primary_key('carbonmonoxide_pkey',
-                          'carbonmonoxide', ['timestamp', 'geom'])
-
 
 def downgrade():
     # Create new column 'id' and autoincrement its value
@@ -35,10 +28,6 @@ def downgrade():
     op.add_column('carbonmonoxide', sa.Column(
         'id', sa.INTEGER(), nullable=False,
         server_default=sa.text("nextval('carbonmonoxide_id_seq'::regclass)")))
-
-    # Drop primary key
-    op.drop_constraint('carbonmonoxide_pkey',
-                       'carbonmonoxide', type_='primary')
 
     # Use 'id' as the new primary key
     op.create_primary_key('carbonmonoxide_pkey', 'carbonmonoxide', ['id'])

--- a/emissionsapi/db.py
+++ b/emissionsapi/db.py
@@ -9,8 +9,8 @@ from functools import wraps
 import logging
 
 import sqlalchemy
-from sqlalchemy import and_, or_, create_engine, Column, DateTime, Integer, \
-        Float, String, PickleType
+from sqlalchemy import and_, or_, create_engine, Column, DateTime, Float, \
+    String, PickleType
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
@@ -36,8 +36,8 @@ Base = declarative_base()
 
 # Add psycopg2 adapter for pandas Series
 psycopg2.extensions.register_adapter(
-        pandas.core.series.Series,
-        lambda arr: psycopg2.extensions.adapt(list(arr)))
+    pandas.core.series.Series,
+    lambda arr: psycopg2.extensions.adapt(list(arr)))
 
 
 class AlembicVersion(Base):
@@ -100,13 +100,12 @@ class Carbonmonoxide(Base):
     """ORM object for carbon monoxide point
     """
     __tablename__ = 'carbonmonoxide'
-    id = Column(Integer, primary_key=True)
-    """ Data sample identifier (primary key)"""
     value = Column(Float)
     """Carbon monoxide value"""
-    timestamp = Column(DateTime, index=True)
+    timestamp = Column(DateTime, primary_key=True)
     """Timestamp of measurement"""
-    geom = Column(geoalchemy2.Geometry(geometry_type="POINT"))
+    geom = Column(geoalchemy2.Geometry(
+        geometry_type="POINT"), primary_key=True)
     """Location (PostGis type)"""
 
     def __init__(self, value, longitude, latitude, timestamp):


### PR DESCRIPTION
We do have an `id` on the carbonmonoxide table which we are not using.
So we should drop it to save space.