### PR TITLE
Add openapi specification to python package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ jobs:
             python -c "import emissionsapi.download"
             python -c "import emissionsapi.db"
             python -c "import emissionsapi.preprocess"
+            python -c "import emissionsapi.web"
             deactivate
             rm -r /tmp/module-env
   preprocess:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include emissionsapi/openapi.yml

--- a/emissionsapi/web.py
+++ b/emissionsapi/web.py
@@ -6,8 +6,9 @@
 the users.
 """
 from functools import wraps
-import logging
 import dateutil.parser
+import logging
+import os.path
 
 import connexion
 import json
@@ -298,7 +299,8 @@ def get_statistics(session, interval='day', wkt=None, distance=None,
 app = connexion.App(__name__)
 
 # Add swagger description to api
-app.add_api('openapi.yml', )
+app.add_api(os.path.join(os.path.abspath(
+    os.path.dirname(__file__)), 'openapi.yml'), )
 
 # Create app to run with wsgi server
 application = app.app

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ def read(filename):
     with open(os.path.join(path, filename), encoding='utf-8') as f:
         return f.read()
 
+
 setup(
     name='emissions-api',
     author='Emissions API Developers',
@@ -24,6 +25,7 @@ setup(
         's5a',
         'SQLAlchemy',
     ],
+    include_package_data=True,
     long_description=read('README.rst'),
     long_description_content_type='text/x-rst',
     entry_points={


### PR DESCRIPTION
The openapi specification `openapi.yml` is needed for `emissionsapi.web` to be
importable and runnable.

This patch adds this file to the python package and adapts the paths to find
it.

Closes #76