### PR TITLE
Avoid ORM Objects For Points Endpoint

### DIFF
--- a/emissionsapi/db.py
+++ b/emissionsapi/db.py
@@ -187,12 +187,13 @@ def get_points(session):
 
     :param session: SQLAlchemy Session
     :type session: sqlalchemy.orm.session.Session
-    :return: SQLAlchemy Query with tuple of Carbonmonoxide object,
-             longitude and latitude.
+    :return: SQLAlchemy Query returning tuples of value, timestamp, longitude,
+             and latitude.
     :rtype: sqlalchemy.orm.query.Query
     """
     return session.query(
-        Carbonmonoxide,
+        Carbonmonoxide.value,
+        Carbonmonoxide.timestamp,
         Carbonmonoxide.geom.ST_X(),
         Carbonmonoxide.geom.ST_Y())
 

--- a/emissionsapi/web.py
+++ b/emissionsapi/web.py
@@ -185,13 +185,13 @@ def get_data(session, wkt=None, distance=None, begin=None, end=None,
     query = emissionsapi.db.limit_offset_query(
         query, limit=limit, offset=offset)
 
-    for obj, longitude, latitude in query:
+    for value, timestamp, longitude, latitude in query:
         # Create and append single features.
         features.append(geojson.Feature(
             geometry=geojson.Point((longitude, latitude)),
             properties={
-                "carbonmonoxide": obj.value,
-                "timestamp": obj.timestamp
+                "carbonmonoxide": value,
+                "timestamp": timestamp
             }))
     # Create feature collection from gathered points
     feature_collection = geojson.FeatureCollection(features)


### PR DESCRIPTION
This patch switches from using ORM objects for data point responses to
selecting the returned values directly from the database table to
significantly increase the endpoint performance.

Example for a four day database. Before:

```
[lars@lkiesow]~% repeat 5 /usr/bin/time -p curl -s -o /dev/null "http://127.0.0.1:5000/api/v1/geo.json?country=DE&begin=2019-12-01&end=2019-12-05&limit=99999999999" 2>&1 | grep real
real 1.76
real 1.67
real 1.63
real 1.71
real 1.69
```

After:

```
[lars@lkiesow]~% repeat 5 /usr/bin/time -p curl -s -o /dev/null "http://127.0.0.1:5000/api/v1/geo.json?country=DE&begin=2019-12-01&end=2019-12-05&limit=99999999999" 2>&1 | grep real
real 0.76
real 0.75
real 0.78
real 0.77
real 0.82
```