### PR TITLE
Fix Installation Test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,13 @@ commands:
           command: |
               apt update
               apt install -y build-essential libcurl4-gnutls-dev libgnutls28-dev \
-                  libpq-dev python3 python3-venv python3-dev
+                  libpq-dev python3 python3-venv python3-dev cmake git
       - run:
           name: install emissions-api in virtualenv
           command: |
-              python3 -m venv << parameters.virtualenv >>
+              python3 -m venv "<< parameters.virtualenv >>"
+              "<< parameters.virtualenv >>/bin/pip" install -q -r requirements.txt
               cp .testdata/emissionsapi.yml .
-              << parameters.virtualenv >>/bin/pip install -r requirements.txt
   wait_for_database:
     description: command to wait on the database become available
     parameters:


### PR DESCRIPTION
This patch fixes the issues we have seen on the installation tests for
all recent library updates by activating the created virtual environment
during Python package installation, as well as by providing `cmake` and
`git` as additional tools.