### PR TITLE
Fix Alembic Importing Emissionsapi

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,11 +1,15 @@
 from logging.config import fileConfig
 
+import os
+import sys
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
 
 from alembic import context
 
-import emissionsapi.db
+home_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..')
+sys.path.insert(1, home_dir)
+import emissionsapi.db  # noqa: E402
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.


### PR DESCRIPTION
If the `emissionsapi` package is not installed, execurting e.g. `alembic
current` will result in an error like this:

```
Traceback (most recent call last):
  File "/home/lars/dev/emissions-api/emissions-api/venv/bin/alembic", line 11, in <module>
    load_entry_point('alembic==1.3.2', 'console_scripts', 'alembic')()
  File "/home/lars/dev/emissions-api/emissions-api/venv/lib64/python3.7/site-packages/alembic/config.py", line 575, in main
    CommandLine(prog=prog).main(argv=argv)
  File "/home/lars/dev/emissions-api/emissions-api/venv/lib64/python3.7/site-packages/alembic/config.py", line 569, in main
    self.run_cmd(cfg, options)
  File "/home/lars/dev/emissions-api/emissions-api/venv/lib64/python3.7/site-packages/alembic/config.py", line 549, in run_cmd
    **dict((k, getattr(options, k, None)) for k in kwarg)
  File "/home/lars/dev/emissions-api/emissions-api/venv/lib64/python3.7/site-packages/alembic/command.py", line 515, in current
    script.run_env()
  File "/home/lars/dev/emissions-api/emissions-api/venv/lib64/python3.7/site-packages/alembic/script/base.py", line 489, in run_env
    util.load_python_file(self.dir, "env.py")
  File "/home/lars/dev/emissions-api/emissions-api/venv/lib64/python3.7/site-packages/alembic/util/pyfiles.py", line 98, in load_python_file
    module = load_module_py(module_id, path)
  File "/home/lars/dev/emissions-api/emissions-api/venv/lib64/python3.7/site-packages/alembic/util/compat.py", line 173, in load_module_py
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "alembic/env.py", line 8, in <module>
    import emissionsapi.db
ModuleNotFoundError: No module named 'emissionsapi'
```

This patch fixes the problem by adding emissionapi's root directory to
Python's package search path.