### PR TITLE
Update C Dependencies in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,7 @@ commands:
           name: install base dependencies
           command: |
               apt update
-              # libcurl4-gnutls-dev libgnutls28-dev can be remove later, but for now they are used for the migration tests
               apt install -y build-essential \
-                  libcurl4-gnutls-dev libgnutls28-dev \
                   libpq-dev python3 python3-venv python3-dev cmake git
       - run:
           name: install emissions-api in virtualenv


### PR DESCRIPTION
Since master does not depend on pycurl anymore, we can safely remove the pycurl
c dependencies, since they are not longer needed fot the migration tests.