### PR TITLE
Use a connection per fork in preprocess

### DIFF
--- a/emissionsapi/preprocess.py
+++ b/emissionsapi/preprocess.py
@@ -121,8 +121,13 @@ def main():
 
     for name, attributes in emissionsapi.db.products.items():
         logger.info('Preprocessing product %s', name)
+
+        def init():
+            # Clear session maker in fork, due to libpq
+            emissionsapi.db.__session__ = None
+
         # Iterate through all nc files
-        with multiprocessing.Pool(workers) as p:
+        with multiprocessing.Pool(workers, init) as p:
             p.starmap(preprocess_file, zip(
                 sorted(list_ncfiles(attributes['storage'])),
                 itertools.repeat(attributes['table']),


### PR DESCRIPTION
This patch resets the global session maker from, since `libpq` connection have
problems with running on forks, see
https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT and

So every worker in the multiprocessing pool does have its own database
connection.

This fixes the

```
sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) SSL error: decryption failed or bad record mac`
```

Tracebacks during the import.