### PR TITLE
Internal Server Error With No Product Name

### DIFF
--- a/emissionsapi/web.py
+++ b/emissionsapi/web.py
@@ -365,7 +365,7 @@ def get_products():
     return [
         {
             'name': name,
-            'product_variable': attributes['product']
+            'product_variable': attributes.get('product')
         } for name, attributes in emissionsapi.db.products.items()
     ]
 


### PR DESCRIPTION
Not specifying a product like the commented out
`methane_mixing_ratio_bias_corrected` in the following example is fine
when importing files since `s5a` has defaults for the most common
products.

```
products:
  carbonmonoxide:
    storage: data-1day/
    product: carbonmonoxide_total_column
  methane:
    storage: data-ch4-1day/
    #product: methane_mixing_ratio_bias_corrected
```

This, however, leads to an internal server error when querying the `products.json` endpoint:

```
2020-07-22 00:50:47,160 - web - ERROR - Exception on /api/v2/products.json [GET]
Traceback (most recent call last):
  File "/home/lars/dev/emissions-api/emissions-api/venv/lib64/python3.8/site-packages/flask/app.py", line 2446, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/lars/dev/emissions-api/emissions-api/venv/lib64/python3.8/site-packages/flask/app.py", line 1951, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/lars/dev/emissions-api/emissions-api/venv/lib64/python3.8/site-packages/flask/app.py", line 1820, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/lars/dev/emissions-api/emissions-api/venv/lib64/python3.8/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/home/lars/dev/emissions-api/emissions-api/venv/lib64/python3.8/site-packages/flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/lars/dev/emissions-api/emissions-api/venv/lib64/python3.8/site-packages/flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/lars/dev/emissions-api/emissions-api/venv/lib64/python3.8/site-packages/connexion/decorators/decorator.py", line 48, in wrapper
    response = function(request)
  File "/home/lars/dev/emissions-api/emissions-api/venv/lib64/python3.8/site-packages/connexion/decorators/uri_parsing.py", line 144, in wrapper
    response = function(request)
  File "/home/lars/dev/emissions-api/emissions-api/venv/lib64/python3.8/site-packages/connexion/decorators/parameter.py", line 121, in wrapper
    return function(**kwargs)
  File "/home/lars/dev/emissions-api/emissions-api/emissionsapi/web.py", line 365, in get_products
    return [
  File "/home/lars/dev/emissions-api/emissions-api/emissionsapi/web.py", line 368, in <listcomp>
    'product_variable': attributes['product']
KeyError: 'product'
```