### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,10 @@
 version: '2'
 services:
   db:
-    image: mdillon/postgis
+    container_name: emissionsapi-postgres
+    image: docker.io/mdillon/postgis
     ports:
-      - 5432:5432
+      - 127.0.0.1:5432:5432
     environment:
       POSTGRES_USER: user
       POSTGRES_PASSWORD: user


### PR DESCRIPTION
This patch updates the docker-compose file to ensure a specific registry
is names as source for the container. In addition to this, it also
specifies to listen to localhost only and gives a name to the container.