### PR TITLE
No mandatory parameter for geo.json Endpoint

### DIFF
--- a/emissionsapi/openapi.yml
+++ b/emissionsapi/openapi.yml
@@ -21,7 +21,6 @@ paths:
           Get all points in [GeoJSON](https://geojson.org/) format.
 
           The parameters `geoframe`, `country`, `polygon` and `point` are mutually exclusive.
-          Providing one of these parameters is mandatory.
       parameters:
         - $ref: '#/components/parameters/product'
         - $ref: '#/components/parameters/geoframe'

--- a/emissionsapi/web.py
+++ b/emissionsapi/web.py
@@ -95,9 +95,6 @@ def parse_wkt(f):
 
         number_of_parameter = sum(x is not None for x in (
             geoframe, country, polygon, point))
-        if number_of_parameter == 0:
-            return ("You need to specify one of 'geoframe', "
-                    "'country', 'polygon' and 'point'", 400)
         if number_of_parameter > 1:
             return ("'geoframe', 'country', 'polygon' and "
                     "'point' are mutually exclusive", 400)


### PR DESCRIPTION
Since there are not a lot less points in the database, queries to get all
points within a timespan without limiting the geography are reasonable.