### PR TITLE
Faster geo.json

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ connexion==2.7.0
 Fiona==1.8.13.post1
 Flask==1.1.2
 GeoAlchemy2==0.8.4
-geojson==2.5.0
 geopandas==0.8.1
 gunicorn==20.0.4
 idna==2.10


### PR DESCRIPTION
This patch optimize the geo.json endpoint by

* Using the `flask.jsonify` to directly create a `flask.Response` and
  circumvent the slow connexion response creation.
* Creating a plain dictionary for the GeoJSON Feature Collection instead of
  creating lots of objects using the `geojson` library.

Before:

```bash
$ time for i in {1..10}; do curl -s -X GET "http://127.0.0.1:5000/api/v2/carbonmonoxide/geo.json?begin=2019-02-10&end=2019-02-11" -H  "accept: application/json" > /dev/null; done

real    1m32.739s
user    0m0.040s
sys     0m0.102s
```

After:

```bash
time for i in {1..10}; do curl -s -X GET "http://127.0.0.1:5000/api/v2/carbonmonoxide/geo.json?begin=2019-02-10&end=2019-02-11" -H  "accept: application/json" > /dev/null; done

real    0m32.576s
user    0m0.067s
sys     0m0.037s
```