### PR TITLE
Allow more Dependabot Pull Requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,4 @@ updates:
   schedule:
     interval: monthly
     time: "04:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 25


### PR DESCRIPTION
Since we have set the update frequency to monthly, there may easily be more than 10 updates at the same time.