### PR TITLE
Endpoint for Country Codes

### DIFF
--- a/.github/api-test.sh
+++ b/.github/api-test.sh
@@ -30,3 +30,8 @@ do
         done
     done
 done
+
+# Test contry codes
+api_call countries.json \
+    | jq -r .DE \
+    | grep -i Germany

--- a/emissionsapi/country_shapes.py
+++ b/emissionsapi/country_shapes.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 
 # Global country shape storage
 __country_shapes__ = {}
+__country_names__ = {}
 
 
 class CountryNotFound(Exception):
@@ -39,6 +40,8 @@ def __load_country_shapes__():
         shape = country['geometry']
         __country_shapes__[country_codes.alpha2] = shape
         __country_shapes__[country_codes.alpha3] = shape
+        __country_names__[country_codes.alpha2] = country['name']
+        __country_names__[country_codes.alpha3] = country['name']
 
 
 def get_country_wkt(country):
@@ -57,3 +60,15 @@ def get_country_wkt(country):
         return __country_shapes__[country].wkt
     except KeyError:
         raise CountryNotFound
+
+
+def get_country_codes():
+    '''Get list of country codes and names.
+
+    :return: Map of country codes and names
+    :rtype: dict
+    '''
+    if not __country_shapes__:
+        __load_country_shapes__()
+
+    return __country_names__

--- a/emissionsapi/openapi.yml
+++ b/emissionsapi/openapi.yml
@@ -11,8 +11,8 @@ info:
     url: https://emissions-api.org
     email: info@emissions-api.org
 externalDocs:
-  description: Source code documentation
-  url: https://docs.emissions-api.org
+  description: GitHub project
+  url: https://github.com/emissions-api/emissions-api
 paths:
   /api/v2/{product}/geo.json:
     get:
@@ -121,6 +121,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Products'
+  /api/v2/countries.json:
+    get:
+      operationId: emissionsapi.web.get_country_codes
+      description: |
+          Get list of valid country codes and names.
+      responses:
+        200:
+          description: Object with country codes and names.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Countries'
 
 components:
   parameters:
@@ -351,3 +363,11 @@ components:
             type: string
             example: carbonmonoxide_total_column
             description: Name of the variable as defined from the ESA from within the processed files.
+    Countries:
+      type: object
+      additionalProperties:
+        type: string
+      example:
+        BE: Belgium
+        DE: Germany
+        DEU: Germany

--- a/emissionsapi/web.py
+++ b/emissionsapi/web.py
@@ -17,6 +17,7 @@ from h3 import h3
 
 import emissionsapi.db
 from emissionsapi.country_shapes import CountryNotFound, get_country_wkt
+from emissionsapi.country_shapes import get_country_codes  # noqa - used in API
 from emissionsapi.utils import bounding_box_to_wkt, polygon_to_wkt, \
     RESTParamError
 


### PR DESCRIPTION
This patch adds an endpoint to get all available country codes and
associated country names which can be used in other API endpoints to
specify shapes.