### PR TITLE
Add Product Descriptions

### DIFF
--- a/emissionsapi/db.py
+++ b/emissionsapi/db.py
@@ -33,7 +33,9 @@ products = config('products') or {
     'carbonmonoxide': {
         'storage': 'data',
         'product': 'carbonmonoxide_total_column',
-        'product_key': 'L2__CO____'
+        'product_key': 'L2__CO____',
+        'description': 'Average atmosphere mole content of carbon monoxide in '
+                       '`mol m¯²`'
     }
 }
 

--- a/emissionsapi/openapi.yml
+++ b/emissionsapi/openapi.yml
@@ -347,6 +347,10 @@ components:
             type: string
             example: carbonmonoxide
             description: Name of the product
+          description:
+            type: string
+            example: Average atmosphere mole content of carbon monoxide
+            description: Description of data type and unit.
           product_variable:
             type: string
             example: carbonmonoxide_total_column

--- a/emissionsapi/web.py
+++ b/emissionsapi/web.py
@@ -373,7 +373,8 @@ def get_products():
     return [
         {
             'name': name,
-            'product_variable': attributes.get('product')
+            'product_variable': attributes.get('product'),
+            'description': attributes.get('description'),
         } for name, attributes in emissionsapi.db.products.items()
     ]
 

--- a/etc/emissionsapi.yml
+++ b/etc/emissionsapi.yml
@@ -31,6 +31,7 @@ latest_data:
 # }
 products:
   carbonmonoxide:
+    description: Average atmosphere mole content of carbon monoxide in `mol m¯²`
     storage: data
     product: carbonmonoxide_total_column
     product_key: L2__CO____


### PR DESCRIPTION
This patch allows adding descriptions for each product so that users
actually know what the given data means.

This fixes #290