### PR TITLE
Update to sentinel5dl 1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ psycopg2==2.9.1
 python-dateutil==2.8.2
 PyYAML==5.4.1
 s5a==0.4
-sentinel5dl==1.0
+sentinel5dl==1.1
 SQLAlchemy==1.4.25
 swagger-ui-bundle==0.0.9


### PR DESCRIPTION
sentinel5dl 1.1 has just been released and includes a few bug fixes
interesting for Emissions API. This patch updates the version
requirement.