### PR TITLE
Test Against CentOS Stream 8

### DIFF
--- a/.github/emissionsapi.dockerfile
+++ b/.github/emissionsapi.dockerfile
@@ -1,4 +1,4 @@
-FROM registry.hub.docker.com/library/centos:8
+FROM quay.io/centos/centos:stream8
 
 # Prerequites
 RUN dnf install -y epel-release 'dnf-command(config-manager)'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,10 @@ jobs:
         run: docker-compose -f .github/docker-compose.yml build emissionsapi
       - name: Spin up database and emissions-api web server
         run: docker-compose -f .github/docker-compose.yml up -d
+      - name: Log information about s5phub.copernicus.eu
+        run: dig +short s5phub.copernicus.eu
+      - name: Test connection to s5phub.copernicus.eu
+        run: curl -I https://s5phub.copernicus.eu
       - name: Wait for database
         run: until PGPASSWORD=user psql -h 127.0.0.1 -U user db -c '\q'; do sleep 1; done
       - name: Check if emissions-api web server is up


### PR DESCRIPTION
This patch updates the test environment from CentOS 8 to CentOS Stream 8
since the former is no longer supported and the latter is a drop-in
replacement.