### PR TITLE
Fix Flake8 Linting Error

### DIFF
--- a/emissionsapi/utils.py
+++ b/emissionsapi/utils.py
@@ -5,7 +5,8 @@
 
 
 class RESTParamError(ValueError):
-    """User-specific exception, used in :func:`~emissionsapi.utils.polygon_to_wkt`.
+    """User-specific exception, used in
+    :func:`~emissionsapi.utils.polygon_to_wkt`.
     """
     pass
 


### PR DESCRIPTION
New versions of flake 8 started complaining about the line length of a comment. This patch fixes the issue.