### PR TITLE
 Don't Run Tests Twice on Dependabot Pull Requests 

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,10 @@
 name: Build and deploy Docs
 
 on:
-  - push
-  - pull_request
+  - push:
+      branches-ignore:
+        - 'dependabot/**'  # Don't run on dependabot branches, as they are already covered by pull requests
+  - pull_request:
 
 jobs:
   docs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,10 @@
 name: Lint
 
 on:
-  - push
-  - pull_request
+  - push:
+      branches-ignore:
+        - 'dependabot/**'  # Don't run on dependabot branches, as they are already covered by pull requests
+  - pull_request:
 
 jobs:
   flake8:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,10 @@
 name: Integration Test
 
 on:
-  - push
-  - pull_request
+  - push:
+      branches-ignore:
+        - 'dependabot/**'  # Don't run on dependabot branches, as they are already covered by pull requests
+  - pull_request:
 
 jobs:
   install-autoupdate-api:


### PR DESCRIPTION
This patch prevents tests from running twice on Dependabot pull requests by excluding the dependabot branches from push actions.