### PR TITLE
Run CodeQL on Correct Branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,10 +2,12 @@ name: CodeQL
 
 on:
   push:
-    branches: master
+    branches:
+      - main
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches:
+      - main
   schedule:
     - cron: '0 14 * * 0'
 


### PR DESCRIPTION
CodeQL was still set to run against `master` instead of `main`. This pull request fixes that issue.