### PR TITLE
Add Request Metrics

### DIFF
--- a/emissionsapi/db.py
+++ b/emissionsapi/db.py
@@ -10,7 +10,7 @@ import logging
 
 import sqlalchemy
 from sqlalchemy import and_, or_, create_engine, Column, DateTime, Float, \
-    String, PickleType
+    String, Integer, PickleType
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
@@ -65,6 +65,16 @@ class File(Base):
     __tablename__ = 'file'
     filename = Column(String, primary_key=True)
     """Name of processed data file"""
+
+
+class Counter(Base):
+    """ORM object for counting the number of requests
+    """
+    __tablename__ = 'counter'
+    function = Column(String, primary_key=True)
+    """Name of endpoint to count"""
+    counter = Column(Integer)
+    """Counter value"""
 
 
 class Cache(Base):

--- a/emissionsapi/metrics/requests_collector.py
+++ b/emissionsapi/metrics/requests_collector.py
@@ -1,0 +1,29 @@
+from prometheus_client.core import CounterMetricFamily
+from prometheus_client.registry import REGISTRY
+
+import emissionsapi.db
+
+
+class RequestsCollector(object):
+    '''Collector for number of requests made to different functions.
+    '''
+
+    def __init__(self, registry=REGISTRY):
+        registry.register(self)
+
+    def collect(self):
+        '''Collect the current number of requests made against different
+        methods of the Emissions API.
+        '''
+        # Create counter metric
+        counters = CounterMetricFamily(
+                'requests_count',
+                'Counted number of requests',
+                labels=['method'])
+
+        # Get requests count from database
+        with emissionsapi.db.get_session() as session:
+            for counter in session.query(emissionsapi.db.Counter).all():
+                counters.add_metric([counter.function], counter.counter)
+
+        yield counters

--- a/emissionsapi/openapi.yml
+++ b/emissionsapi/openapi.yml
@@ -16,7 +16,7 @@ externalDocs:
 paths:
   /api/v2/{product}/geo.json:
     get:
-      operationId: emissionsapi.web.get_data
+      operationId: emissionsapi.web.get_geo_data
       description: |
           Get all points in [GeoJSON](https://geojson.org/) format.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ s5a==0.4
 sentinel5dl==1.2
 SQLAlchemy==1.4.41
 swagger-ui-bundle==0.0.9
+prometheus_client==0.14.1


### PR DESCRIPTION
This patch adds a simple metrics endpoint for use with Prometheus. Alongside the default Python internal data you get from the client library, this starts counting requests made against different parts of the API.

The result will look something like this:

```
❯ curl -s http://127.0.0.1:5000/metrics | grep request
requests_count_total{method="get_data_range"} 5.0
requests_count_total{method="get_data"} 2.0
requests_count_total{method="get_statistics"} 1.0
requests_count_total{method="get_average"} 1.0
requests_count_total{method="get_products"} 28.0
```

This will give us basic usage statistics.