### PR TITLE
More Generic Metrics Backend

### DIFF
--- a/emissionsapi/metrics/requests_collector.py
+++ b/emissionsapi/metrics/requests_collector.py
@@ -1,7 +1,7 @@
 from prometheus_client.core import CounterMetricFamily
 from prometheus_client.registry import REGISTRY
 
-import emissionsapi.db
+from emissionsapi.db import get_session, Metrics
 
 
 class RequestsCollector(object):
@@ -22,8 +22,12 @@ class RequestsCollector(object):
                 labels=['method'])
 
         # Get requests count from database
-        with emissionsapi.db.get_session() as session:
-            for counter in session.query(emissionsapi.db.Counter).all():
-                counters.add_metric([counter.function], counter.counter)
+        with get_session() as session:
+            metrics = session\
+                    .query(Metrics)\
+                    .filter(Metrics.metric == 'request_count')\
+                    .all()
+            for metric in metrics:
+                counters.add_metric([metric.label], metric.value)
 
         yield counters

--- a/emissionsapi/web.py
+++ b/emissionsapi/web.py
@@ -70,17 +70,12 @@ def request_counter(f):
         with emissionsapi.db.get_session() as session:
             with session.begin():
                 # Update counter in database
-                rows_affected = session\
-                    .query(emissionsapi.db.Counter)\
-                    .filter(emissionsapi.db.Counter.function == f.__name__)\
-                    .update({'counter': emissionsapi.db.Counter.counter + 1})
-
-                # We didn't modify anything. We need to insert the first value
-                if not rows_affected:
-                    session.add(emissionsapi.db.Counter(
-                            function=f.__name__,
-                            counter=1))
-
+                emissionsapi.db.Metrics.update(
+                        session,
+                        'request_count',
+                        f.__name__,
+                        emissionsapi.db.Metrics.value + 1,
+                        1)
         return f(*args, **kwargs)
     return wrapper
 


### PR DESCRIPTION
This patch basically provides an alternative to pull request #464.

This uses a more generic database table structure which will allow us to use the same table for other metrics as well and not only for the request counters.

We can use this to add more metrics and then just need to add an additional collector exporting these for the metrics endpoint.

This patch does not modify the current behavior of the metrics endpoint. It only changes the storage.