### PR TITLE
Mark metrics label as not null

### DIFF
--- a/emissionsapi/db.py
+++ b/emissionsapi/db.py
@@ -73,7 +73,7 @@ class Metrics(Base):
     __tablename__ = 'metrics'
     metric = Column(String, primary_key=True)
     """Name of endpoint to count"""
-    label = Column(String, primary_key=True, nullable=True)
+    label = Column(String, primary_key=True)
     """Label value for specific metric"""
     value = Column(Float)
     """Metric value"""


### PR DESCRIPTION
PostgreSQL enforces that all parts of a primary key are not null [1]. This means that even though the `label` column of the `metrics` table is marked as nullable, actually trying to store `null` will fail.

To be less confusing, this patch removes the nullable SQLAlchemy code.

[1] https://stackoverflow.com/a/45290490/2352895