### PR TITLE
Correctly use value as default value for metrics

### DIFF
--- a/emissionsapi/db.py
+++ b/emissionsapi/db.py
@@ -79,7 +79,7 @@ class Metrics(Base):
     """Metric value"""
 
     @classmethod
-    def update(cls, session, metric, label, value, initial_value=value):
+    def update(cls, session, metric, label, value, initial_value=None):
         """Update a metrics value.
         If it does not yet exist, this will create a new metrics value.
 
@@ -101,6 +101,8 @@ class Metrics(Base):
 
         # We didn't modify anything. We need to insert the first value
         if not rows_affected:
+            if initial_value is None:
+                initial_value = value
             session.add(cls(
                     metric=metric,
                     label=label,


### PR DESCRIPTION
This patch fixes the default value of the `initial_value` field when updating metrics. It was accidentally set to a class variable instead of the parameter passed to that method.