### PR TITLE
Metrics about active imports

### DIFF
--- a/emissionsapi/metrics/imports_collector.py
+++ b/emissionsapi/metrics/imports_collector.py
@@ -1,0 +1,32 @@
+from prometheus_client.core import GaugeMetricFamily
+from prometheus_client.registry import REGISTRY
+
+from emissionsapi.db import get_session, Metrics
+
+
+class ImportsCollector(object):
+    '''Collector for statistics related to data imports.
+    '''
+
+    def __init__(self, registry=REGISTRY):
+        registry.register(self)
+
+    def collect(self):
+        '''Collect the current number of active imports.
+        '''
+        # Create counter metric
+        imports = GaugeMetricFamily(
+                'active_imports',
+                'Number of active imports',
+                labels=['product'])
+
+        # Get number of active imports from database
+        with get_session() as session:
+            metrics = session\
+                    .query(Metrics)\
+                    .filter(Metrics.metric == 'active_imports')\
+                    .all()
+            for metric in metrics:
+                imports.add_metric([metric.label], metric.value)
+
+        yield imports

--- a/emissionsapi/web.py
+++ b/emissionsapi/web.py
@@ -24,6 +24,7 @@ from emissionsapi.country_shapes import get_country_codes  # noqa - used in API
 from emissionsapi.utils import bounding_box_to_wkt, polygon_to_wkt, \
     RESTParamError
 from emissionsapi.metrics.requests_collector import RequestsCollector
+from emissionsapi.metrics.imports_collector import ImportsCollector
 
 # Logger
 logger = logging.getLogger(__name__)
@@ -451,6 +452,7 @@ def prometheus_metrics():
     # Initialize collectors if they are not yet initialized
     if not __metrics_collectors:
         __metrics_collectors['requests_collector'] = RequestsCollector()
+        __metrics_collectors['imports_collector'] = ImportsCollector()
 
     # Build response
     response = make_response(generate_latest())


### PR DESCRIPTION
This patch adds a metrics collector to provide data about active data imports to the Emissions API.

It will provide metrics like this:

```py
# HELP active_imports Number of active imports
# TYPE active_imports gauge
active_imports{product="carbonmonoxide"} 0.0
```